### PR TITLE
Use conda-forge before conda default chanels

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,9 @@
 name: evaluation-tutorial
 
+channels:
+  - conda-forge
+  - defaults
+
 dependencies:
   - python
   - pandas


### PR DESCRIPTION
Using [conda-forge](https://conda-forge.org/) is preferred when installing package.

Apart from that, everything regarding installation LGTM. :slightly_smiling_face: 